### PR TITLE
Enable debug output only if built with debug tag

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,5 @@
+// +build debug
+
+package letsencrypt
+
+const debug = true

--- a/lets.go
+++ b/lets.go
@@ -172,7 +172,6 @@ import (
 )
 
 const letsEncryptURL = "https://acme-v01.api.letsencrypt.org/directory"
-const debug = true
 
 // A Manager m takes care of obtaining and refreshing a collection of TLS certificates
 // obtained by LetsEncrypt.org.

--- a/nodebug.go
+++ b/nodebug.go
@@ -1,0 +1,5 @@
+// +build !debug
+
+package letsencrypt
+
+const debug = false


### PR DESCRIPTION
Log debug output only if built with `-tags debug`. This saves 2 log lines for each https connection under normal operations (`GetCertificate domain` and `Cert domain` lines).
