### PR TITLE
Update acme vendor

### DIFF
--- a/lets.go
+++ b/lets.go
@@ -700,7 +700,7 @@ type tlsProvider struct {
 }
 
 func (p tlsProvider) Present(domain, token, keyAuth string) error {
-	cert, dom, err := acme.TLSSNI01ChallengeCertDomain(keyAuth)
+	cert, dom, err := acme.TLSSNI01ChallengeCert(keyAuth)
 	if err != nil {
 		return err
 	}
@@ -713,7 +713,7 @@ func (p tlsProvider) Present(domain, token, keyAuth string) error {
 }
 
 func (p tlsProvider) CleanUp(domain, token, keyAuth string) error {
-	_, dom, err := acme.TLSSNI01ChallengeCertDomain(keyAuth)
+	_, dom, err := acme.TLSSNI01ChallengeCert(keyAuth)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/xenolf/lego/acme/client.go
+++ b/vendor/github.com/xenolf/lego/acme/client.go
@@ -187,6 +187,68 @@ func (c *Client) Register() (*RegistrationResource, error) {
 	return reg, nil
 }
 
+// DeleteRegistration deletes the client's user registration from the ACME
+// server.
+func (c *Client) DeleteRegistration() error {
+	if c == nil || c.user == nil {
+		return errors.New("acme: cannot unregister a nil client or user")
+	}
+	logf("[INFO] acme: Deleting account for %s", c.user.GetEmail())
+
+	regMsg := registrationMessage{
+		Resource: "reg",
+		Delete:   true,
+	}
+
+	_, err := postJSON(c.jws, c.user.GetRegistration().URI, regMsg, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// QueryRegistration runs a POST request on the client's registration and
+// returns the result.
+//
+// This is similar to the Register function, but acting on an existing
+// registration link and resource.
+func (c *Client) QueryRegistration() (*RegistrationResource, error) {
+	if c == nil || c.user == nil {
+		return nil, errors.New("acme: cannot query the registration of a nil client or user")
+	}
+	// Log the URL here instead of the email as the email may not be set
+	logf("[INFO] acme: Querying account for %s", c.user.GetRegistration().URI)
+
+	regMsg := registrationMessage{
+		Resource: "reg",
+	}
+
+	var serverReg Registration
+	hdr, err := postJSON(c.jws, c.user.GetRegistration().URI, regMsg, &serverReg)
+	if err != nil {
+		return nil, err
+	}
+
+	reg := &RegistrationResource{Body: serverReg}
+
+	links := parseLinks(hdr["Link"])
+	// Location: header is not returned so this needs to be populated off of
+	// existing URI
+	reg.URI = c.user.GetRegistration().URI
+	if links["terms-of-service"] != "" {
+		reg.TosURL = links["terms-of-service"]
+	}
+
+	if links["next"] != "" {
+		reg.NewAuthzURL = links["next"]
+	} else {
+		return nil, errors.New("acme: No new-authz link in response to registration query")
+	}
+
+	return reg, nil
+}
+
 // AgreeToTOS updates the Client registration and sends the agreement to
 // the server.
 func (c *Client) AgreeToTOS() error {

--- a/vendor/github.com/xenolf/lego/acme/http.go
+++ b/vendor/github.com/xenolf/lego/acme/http.go
@@ -14,8 +14,11 @@ import (
 // UserAgent (if non-empty) will be tacked onto the User-Agent string in requests.
 var UserAgent string
 
+// HTTPTimeout is used to override the default HTTP timeout of 10 seconds.
+var HTTPTimeout = 10 * time.Second
+
 // defaultClient is an HTTP client with a reasonable timeout value.
-var defaultClient = http.Client{Timeout: 10 * time.Second}
+var defaultClient = http.Client{Timeout: HTTPTimeout}
 
 const (
 	// defaultGoUserAgent is the Go HTTP package user agent string. Too

--- a/vendor/github.com/xenolf/lego/acme/jws.go
+++ b/vendor/github.com/xenolf/lego/acme/jws.go
@@ -101,7 +101,9 @@ func (j *jws) Nonce() (string, error) {
 			return nonce, err
 		}
 	}
-
+	if len(j.nonces) == 0 {
+		return "", fmt.Errorf("Can't get nonce")
+	}
 	nonce, j.nonces = j.nonces[len(j.nonces)-1], j.nonces[:len(j.nonces)-1]
 	return nonce, nil
 }

--- a/vendor/github.com/xenolf/lego/acme/messages.go
+++ b/vendor/github.com/xenolf/lego/acme/messages.go
@@ -22,6 +22,7 @@ type recoveryKeyMessage struct {
 type registrationMessage struct {
 	Resource string   `json:"resource"`
 	Contact  []string `json:"contact"`
+	Delete   bool     `json:"delete,omitempty"`
 	//	RecoveryKey recoveryKeyMessage `json:"recoveryKey,omitempty"`
 }
 

--- a/vendor/github.com/xenolf/lego/acme/tls_sni_challenge.go
+++ b/vendor/github.com/xenolf/lego/acme/tls_sni_challenge.go
@@ -41,7 +41,7 @@ func (t *tlsSNIChallenge) Solve(chlng challenge, domain string) error {
 }
 
 // TLSSNI01ChallengeCert returns a certificate and target domain for the `tls-sni-01` challenge
-func TLSSNI01ChallengeCertDomain(keyAuth string) (tls.Certificate, string, error) {
+func TLSSNI01ChallengeCert(keyAuth string) (tls.Certificate, string, error) {
 	// generate a new RSA key for the certificates
 	tempPrivKey, err := generatePrivateKey(RSA2048)
 	if err != nil {
@@ -64,10 +64,4 @@ func TLSSNI01ChallengeCertDomain(keyAuth string) (tls.Certificate, string, error
 	}
 
 	return certificate, domain, nil
-}
-
-// TLSSNI01ChallengeCert returns a certificate for the `tls-sni-01` challenge
-func TLSSNI01ChallengeCert(keyAuth string) (tls.Certificate, error) {
-	cert, _, err := TLSSNI01ChallengeCertDomain(keyAuth)
-	return cert, err
 }

--- a/vendor/github.com/xenolf/lego/acme/tls_sni_challenge_server.go
+++ b/vendor/github.com/xenolf/lego/acme/tls_sni_challenge_server.go
@@ -30,7 +30,7 @@ func (s *TLSProviderServer) Present(domain, token, keyAuth string) error {
 		s.port = "443"
 	}
 
-	cert, err := TLSSNI01ChallengeCert(keyAuth)
+	cert, _, err := TLSSNI01ChallengeCert(keyAuth)
 	if err != nil {
 		return err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "",
 	"package": [
 		{
-			"checksumSHA1": "CHmdoMriAboKW2nHYSXo0yBizaE=",
+			"checksumSHA1": "enRxG6E7XiaJEEqew+FrHtJ4Igw=",
 			"path": "github.com/xenolf/lego/acme",
-			"revision": "ca19a90028e242e878585941c2a27c8f3b3efc25",
-			"revisionTime": "2016-03-28T16:28:34Z"
+			"revision": "a9d8cec0e6563575e5868a005359ac97911b5985",
+			"revisionTime": "2016-06-13T23:31:55Z"
 		},
 		{
 			"checksumSHA1": "jrheBzltbBE1frmNXQiu911T7dE=",


### PR DESCRIPTION
The interface for `acme.TLSSNI01ChallengeCert` has been updated to return a domain. The vendor package no longer needs to rely on an edited version of the package. This will solve issues such as #9 when a different vendoring solution is used by importers.
