### PR TITLE
letsencrypt: fix clearing of hosts list

### DIFF
--- a/lets.go
+++ b/lets.go
@@ -499,7 +499,11 @@ func (m *Manager) Unmarshal(enc string) error {
 func (m *Manager) SetHosts(hosts []string) {
 	m.init()
 	m.mu.Lock()
-	m.state.Hosts = append(m.state.Hosts[:0], hosts...)
+	if len(hosts) > 0 {
+		m.state.Hosts = append(m.state.Hosts[:0], hosts...)
+	} else {
+		m.state.Hosts = nil
+	}
 	m.mu.Unlock()
 	m.updated()
 }


### PR DESCRIPTION
This fixes a problem where all connections are refused with the "unknown hosts" error if `Manager.SetHosts` is called with `nil`  or an empty list.

This fix is required to be able to clear a hosts list that was loaded from the cache file.