### PR TITLE
Add a Go import comment

### DIFF
--- a/lets.go
+++ b/lets.go
@@ -168,7 +168,7 @@
 // serving HTTPS redirects to HTTP clients is provided by m.Serve, as used in
 // the original example above.
 //
-package letsencrypt
+package letsencrypt // import "rsc.io/letsencrypt"
 
 import (
 	"crypto"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in the package
to ensure that this package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
